### PR TITLE
fix warnings on GCC

### DIFF
--- a/keychain_linux.cpp
+++ b/keychain_linux.cpp
@@ -33,6 +33,11 @@ namespace keychain {
 const char *ServiceFieldName = "service";
 const char *AccountFieldName = "username";
 
+// disable warnings about missing initializers in SecretSchema
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
+
 const SecretSchema makeSchema(const std::string &package) {
     return SecretSchema{package.c_str(),
                         SECRET_SCHEMA_NONE,
@@ -53,17 +58,17 @@ void setPassword(const std::string &package, const std::string &service,
     if (!user.empty())
         label += " (" + user + ")";
 
-    gboolean result = secret_password_store_sync(&schema,
-                                                 SECRET_COLLECTION_DEFAULT,
-                                                 label.c_str(),
-                                                 password.c_str(),
-                                                 NULL, // not cancellable
-                                                 &error,
-                                                 ServiceFieldName,
-                                                 service.c_str(),
-                                                 AccountFieldName,
-                                                 user.c_str(),
-                                                 NULL);
+    secret_password_store_sync(&schema,
+                               SECRET_COLLECTION_DEFAULT,
+                               label.c_str(),
+                               password.c_str(),
+                               NULL, // not cancellable
+                               &error,
+                               ServiceFieldName,
+                               service.c_str(),
+                               AccountFieldName,
+                               user.c_str(),
+                               NULL);
 
     if (error != NULL) {
         err.error = KeychainError::GenericError;
@@ -112,14 +117,14 @@ void deletePassword(const std::string &package, const std::string &service,
     const auto schema = makeSchema(package);
     GError *error = NULL;
 
-    gboolean result = secret_password_clear_sync(&schema,
-                                                 NULL, // not cancellable
-                                                 &error,
-                                                 ServiceFieldName,
-                                                 service.c_str(),
-                                                 AccountFieldName,
-                                                 user.c_str(),
-                                                 NULL);
+    secret_password_clear_sync(&schema,
+                               NULL, // not cancellable
+                               &error,
+                               ServiceFieldName,
+                               service.c_str(),
+                               AccountFieldName,
+                               user.c_str(),
+                               NULL);
 
     if (error != NULL) {
         err.error = KeychainError::GenericError;

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -14,7 +14,7 @@ void check_no_error(const Error &ec) {
     INFO(error << " [" << ec.code << "] "
                << ": " << ec.message);
     CHECK(!ec);
-};
+}
 
 TEST_CASE("Keychain", "[keychain]") {
     auto crud = [](const std::string &package,


### PR DESCRIPTION
 * "private" reserved fields in SecretSchema miss initialization -> disable warning
 * remove unused result variables
 * remove extra ;